### PR TITLE
use `lang-reader-module-paths` instead of copy-pasted code

### DIFF
--- a/2d-lib/info.rkt
+++ b/2d-lib/info.rkt
@@ -2,7 +2,7 @@
 
 (define collection "2d")
 (define version "1.1")
-(define deps '("base"
+(define deps '(["base" #:version "6.6.0.3"]
                "scribble-lib"
                "syntax-color-lib"))
 (define pkg-desc "Implementation (no documentation) part of \"2d\"")

--- a/2d-lib/lang/reader.rkt
+++ b/2d-lib/lang/reader.rkt
@@ -15,15 +15,7 @@
   (make-meta-reader
    '2d
    "language path"
-   (lambda (bstr)
-     (let* ([str (bytes->string/latin-1 bstr)]
-            [sym (string->symbol str)])
-       (and (module-path? sym)
-            (vector
-             ;; try submod first:
-             `(submod ,sym reader)
-             ;; fall back to /lang/reader:
-             (string->symbol (string-append str "/lang/reader"))))))
+   lang-reader-module-paths
    wrap-reader
    wrap-reader
    (lambda (proc)


### PR DESCRIPTION
Relies on https://github.com/racket/racket/commit/42dcc525b1e03ca36488b815b45428655fdcbf1b

This replaces the 9-line copy-pasted 3rd argument to `make-meta-reader` with `lang-reader-module-paths` to get the possible module-paths to the reader module of the base language.
