### PR TITLE
Doc: swapped description of lt-chars and rt-chars

### DIFF
--- a/2d-doc/scribblings/2d.scrbl
+++ b/2d-doc/scribblings/2d.scrbl
@@ -340,10 +340,10 @@ parsing 2d syntax.
 }
 
 @doc-chars[lt-chars]{
- All of the 2d chars that connect to the next char.
+ All of the 2d chars that connect to the previous char.
 }
 
 @doc-chars[rt-chars]{
- All of the 2d chars that connect to the previous char.
+ All of the 2d chars that connect to the next char.
 }
 


### PR DESCRIPTION
Unless I'm mistaken, `lt-chars` stands for `left-chars`, and lists all the 2d chars that connect to the **previous** char, not to the next char.

The reverse should be true for `rt-chars`.

Another reason for me to believe this: the list `lt-chars` includes `╗`, which points leftwards to the previous char , while `rt-chars` includes `╚`, which points rightwards, to the next char.